### PR TITLE
fix: formatOpt binding

### DIFF
--- a/src/DateFns.res
+++ b/src/DateFns.res
@@ -23,7 +23,7 @@ type formatOptions = {
   useAdditionalWeekYearTokens: option<bool>,
   useAdditionalDayOfYearTokens: option<bool>,
 }
-@module("date-fns/formatOpt")
+@module("date-fns/format")
 external formatOpt: (Js.Date.t, string, formatOptions) => string = "default"
 
 @module("date-fns/formatDistance")


### PR DESCRIPTION
DateFns 라이브러리 상에서는 formatOpt와 관련된 내용이 보이지 않습니다. 이전 bs-date-fns에서도 DateFns.format을 참조하고 있던 것으로 보여 이를 수정한 내용입니다.